### PR TITLE
removed saved button

### DIFF
--- a/views/partials/memes/meme-block.handlebars
+++ b/views/partials/memes/meme-block.handlebars
@@ -9,7 +9,7 @@
             <p class="card-text">{{about}}</p>
             <p class="card-text"><small class="text">Likes: {{importance}}</small></p>
             <button type="button" data-likes="{{importance}}" class="btn btn-primary btn-lg like"><i class="far fa-thumbs-up"></i></button>
-            <button type="button" class="btn btn-success btn-lg save"><i class="far fa-save"></i></button>
+            {{!-- <button type="button" class="btn btn-success btn-lg save" href="{{imageUrl}}" download={{title}} ><i class="far fa-save"></i></button> --}}
             <button type="button" class="btn btn-danger btn-lg delete"><i class="far fa-trash-alt"></i></button>
         </div>
     </div>


### PR DESCRIPTION
The download attribute no longer works for cross site images and since all of our images are hosted on Imgur it will not work. I have simply commented out the save button. Push this or not it doesn't really matter. Since either way it's non function. In this branch it just doesn't appear.